### PR TITLE
Implement styler service sketch scheduler

### DIFF
--- a/styler-service/build.gradle.kts
+++ b/styler-service/build.gradle.kts
@@ -1,1 +1,24 @@
-plugins { id("org.springframework.boot") version "3.3.0" }
+plugins {
+    id("org.springframework.boot") version "3.3.0"
+    id("io.spring.dependency-management") version "1.1.4"
+    kotlin("jvm") version "1.9.22"
+    kotlin("plugin.spring") version "1.9.22"
+    kotlin("plugin.jpa") version "1.9.22"
+}
+
+java.sourceCompatibility = JavaVersion.VERSION_21
+
+repositories {
+    mavenCentral()
+}
+
+dependencies {
+    implementation("org.springframework.boot:spring-boot-starter-web")
+    implementation("org.springframework.boot:spring-boot-starter-data-jpa")
+    implementation("org.springframework.boot:spring-boot-starter-actuator")
+    implementation("com.fasterxml.jackson.module:jackson-module-kotlin")
+    runtimeOnly("org.postgresql:postgresql:42.7.2")
+    testImplementation("org.springframework.boot:spring-boot-starter-test")
+}
+
+

--- a/styler-service/src/main/kotlin/com/lookgen/styler/Application.kt
+++ b/styler-service/src/main/kotlin/com/lookgen/styler/Application.kt
@@ -1,6 +1,13 @@
 package com.lookgen.styler
+
 import org.springframework.boot.autoconfigure.SpringBootApplication
+import org.springframework.boot.context.properties.ConfigurationPropertiesScan
 import org.springframework.boot.runApplication
+import org.springframework.scheduling.annotation.EnableScheduling
+
 @SpringBootApplication
+@EnableScheduling
+@ConfigurationPropertiesScan("com.lookgen.styler.config")
 class StylerApplication
+
 fun main(args: Array<String>) = runApplication<StylerApplication>(*args)

--- a/styler-service/src/main/kotlin/com/lookgen/styler/config/OpenAiProperties.kt
+++ b/styler-service/src/main/kotlin/com/lookgen/styler/config/OpenAiProperties.kt
@@ -1,0 +1,10 @@
+package com.lookgen.styler.config
+
+import org.springframework.boot.context.properties.ConfigurationProperties
+import java.time.Duration
+
+@ConfigurationProperties(prefix = "openai")
+class OpenAiProperties {
+    lateinit var apiKey: String
+    var readTimeout: Duration = Duration.ofSeconds(120)
+}

--- a/styler-service/src/main/kotlin/com/lookgen/styler/config/StylerProperties.kt
+++ b/styler-service/src/main/kotlin/com/lookgen/styler/config/StylerProperties.kt
@@ -1,0 +1,8 @@
+package com.lookgen.styler.config
+
+import org.springframework.boot.context.properties.ConfigurationProperties
+
+@ConfigurationProperties(prefix = "styler")
+class StylerProperties {
+    var pollMs: Long = 60_000
+}

--- a/styler-service/src/main/kotlin/com/lookgen/styler/domain/Photo.kt
+++ b/styler-service/src/main/kotlin/com/lookgen/styler/domain/Photo.kt
@@ -1,0 +1,18 @@
+package com.lookgen.styler.domain
+
+import jakarta.persistence.*
+
+@Entity
+@Table(name = "photo")
+class Photo(
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    var id: Long = 0,
+
+    @Column(name = "user_id")
+    var userId: Long = 0,
+
+    var url: String = "",
+
+    var ord: Short = 0
+)

--- a/styler-service/src/main/kotlin/com/lookgen/styler/domain/Sketch.kt
+++ b/styler-service/src/main/kotlin/com/lookgen/styler/domain/Sketch.kt
@@ -1,0 +1,22 @@
+package com.lookgen.styler.domain
+
+import jakarta.persistence.*
+import java.time.LocalDateTime
+
+@Entity
+@Table(name = "sketch")
+class Sketch(
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    var id: Long = 0,
+
+    @Column(name = "user_id", unique = true)
+    var userId: Long = 0,
+
+    var content: String = "",
+
+    var tokens: Int = 0,
+
+    @Column(name = "created_at")
+    var createdAt: LocalDateTime = LocalDateTime.now()
+)

--- a/styler-service/src/main/kotlin/com/lookgen/styler/domain/Stage.kt
+++ b/styler-service/src/main/kotlin/com/lookgen/styler/domain/Stage.kt
@@ -1,0 +1,8 @@
+package com.lookgen.styler.domain
+
+enum class Stage {
+    CAPTURED,
+    PENDING_SKETCH,
+    SKETCH_READY,
+    SKETCH_ERROR
+}

--- a/styler-service/src/main/kotlin/com/lookgen/styler/domain/User.kt
+++ b/styler-service/src/main/kotlin/com/lookgen/styler/domain/User.kt
@@ -1,0 +1,23 @@
+package com.lookgen.styler.domain
+
+import jakarta.persistence.*
+import java.time.LocalDateTime
+
+@Entity
+@Table(name = "user")
+class User(
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    var id: Long = 0,
+
+    @Enumerated(EnumType.STRING)
+    var stage: Stage = Stage.CAPTURED,
+
+    @Column(name = "retry_count")
+    var retryCount: Short = 0,
+
+    @Column(name = "updated_at")
+    var updatedAt: LocalDateTime = LocalDateTime.now(),
+
+    var style: String? = null
+)

--- a/styler-service/src/main/kotlin/com/lookgen/styler/repo/PhotoRepository.kt
+++ b/styler-service/src/main/kotlin/com/lookgen/styler/repo/PhotoRepository.kt
@@ -1,0 +1,10 @@
+package com.lookgen.styler.repo
+
+import com.lookgen.styler.domain.Photo
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.stereotype.Repository
+
+@Repository
+interface PhotoRepository : JpaRepository<Photo, Long> {
+    fun findByUserIdOrderByOrd(userId: Long): List<Photo>
+}

--- a/styler-service/src/main/kotlin/com/lookgen/styler/repo/SketchRepository.kt
+++ b/styler-service/src/main/kotlin/com/lookgen/styler/repo/SketchRepository.kt
@@ -1,0 +1,10 @@
+package com.lookgen.styler.repo
+
+import com.lookgen.styler.domain.Sketch
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.stereotype.Repository
+
+@Repository
+interface SketchRepository : JpaRepository<Sketch, Long> {
+    fun findByUserId(userId: Long): Sketch?
+}

--- a/styler-service/src/main/kotlin/com/lookgen/styler/repo/UserRepository.kt
+++ b/styler-service/src/main/kotlin/com/lookgen/styler/repo/UserRepository.kt
@@ -1,0 +1,17 @@
+package com.lookgen.styler.repo
+
+import com.lookgen.styler.domain.User
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Query
+import org.springframework.data.repository.query.Param
+import org.springframework.stereotype.Repository
+
+@Repository
+interface UserRepository : JpaRepository<User, Long> {
+
+    @Query(
+        value = "SELECT * FROM \"user\" WHERE stage='PENDING_SKETCH' ORDER BY updated_at FOR UPDATE SKIP LOCKED LIMIT :limit",
+        nativeQuery = true
+    )
+    fun findPending(@Param("limit") limit: Int): List<User>
+}

--- a/styler-service/src/main/kotlin/com/lookgen/styler/service/OpenAiClient.kt
+++ b/styler-service/src/main/kotlin/com/lookgen/styler/service/OpenAiClient.kt
@@ -1,0 +1,73 @@
+package com.lookgen.styler.service
+
+import com.lookgen.styler.config.OpenAiProperties
+import io.micrometer.core.instrument.MeterRegistry
+import org.springframework.http.HttpHeaders
+import org.springframework.http.MediaType
+import org.springframework.stereotype.Component
+import org.springframework.web.reactive.function.client.WebClient
+import reactor.core.publisher.Mono
+
+@Component
+class OpenAiClient(
+    private val props: OpenAiProperties,
+    private val meterRegistry: MeterRegistry
+) {
+    private val client = WebClient.builder()
+        .baseUrl("https://api.openai.com/v1/chat/completions")
+        .defaultHeader(HttpHeaders.AUTHORIZATION, "Bearer ${'$'}{props.apiKey}")
+        .build()
+
+    data class Response(val content: String, val tokens: Int)
+
+    fun createSketch(urls: List<String>, style: String?): Response {
+        val payload = mapOf(
+            "model" to "gpt-4o-mini",
+            "stream" to false,
+            "messages" to listOf(
+                mapOf("role" to "system", "content" to "Você é um estilista"),
+                mapOf(
+                    "role" to "user",
+                    "content" to buildContent(urls, style)
+                )
+            )
+        )
+
+        return try {
+            val result = client.post()
+                .contentType(MediaType.APPLICATION_JSON)
+                .bodyValue(payload)
+                .retrieve()
+                .bodyToMono(Map::class.java)
+                .doOnError { meterRegistry.counter("openai_requests_total", "status", "error").increment() }
+                .block(props.readTimeout)
+
+            meterRegistry.counter("openai_requests_total", "status", "success").increment()
+
+            val choice = ((result?.get("choices") as List<*>?)?.firstOrNull() as Map<*, *>?)
+            val message = choice?.get("message") as Map<*, *>?
+            val content = message?.get("content") as String? ?: ""
+            val usage = result?.get("usage") as Map<*, *>?
+            val tokens = (usage?.get("total_tokens") as Number?)?.toInt() ?: 0
+            usage?.forEach { (k, v) ->
+                if (v is Number) {
+                    meterRegistry.counter("openai_token_usage_total", "type", k.toString()).increment(v.toDouble())
+                }
+            }
+            Response(content, tokens)
+        } catch (ex: Exception) {
+            meterRegistry.counter("openai_requests_total", "status", "error").increment()
+            throw ex
+        }
+    }
+
+    private fun buildContent(urls: List<String>, style: String?): List<Any> {
+        val list = mutableListOf<Any>(mapOf("type" to "text", "text" to "Crie um esboço:"))
+        urls.forEach { u ->
+            list += mapOf("type" to "image_url", "image_url" to mapOf("url" to u))
+        }
+        style?.let { list += mapOf("type" to "text", "text" to it) }
+        list += mapOf("type" to "text", "text" to "Bullets, paleta e peças-chave.")
+        return list
+    }
+}

--- a/styler-service/src/main/kotlin/com/lookgen/styler/service/SketchScheduler.kt
+++ b/styler-service/src/main/kotlin/com/lookgen/styler/service/SketchScheduler.kt
@@ -1,0 +1,57 @@
+package com.lookgen.styler.service
+
+import com.lookgen.styler.config.StylerProperties
+import com.lookgen.styler.domain.Stage
+import com.lookgen.styler.domain.Sketch
+import com.lookgen.styler.domain.User
+import com.lookgen.styler.repo.PhotoRepository
+import com.lookgen.styler.repo.SketchRepository
+import com.lookgen.styler.repo.UserRepository
+import io.micrometer.core.instrument.MeterRegistry
+import io.micrometer.core.instrument.Timer
+import org.slf4j.LoggerFactory
+import org.springframework.scheduling.annotation.Scheduled
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+import java.time.LocalDateTime
+
+@Service
+class SketchScheduler(
+    private val userRepo: UserRepository,
+    private val photoRepo: PhotoRepository,
+    private val sketchRepo: SketchRepository,
+    private val openAi: OpenAiClient,
+    private val meterRegistry: MeterRegistry
+) {
+    private val log = LoggerFactory.getLogger(javaClass)
+
+    @Scheduled(fixedDelayString = "\${styler.poll-ms}")
+    @Transactional
+    fun tick() {
+        val users = userRepo.findPending(5)
+        users.forEach { processUser(it) }
+    }
+
+    private fun processUser(user: User) {
+        val timer = Timer.start(meterRegistry)
+        try {
+            val photos = photoRepo.findByUserIdOrderByOrd(user.id)
+            if (photos.size != 5) throw IllegalStateException("Expected 5 photos")
+            val urls = photos.sortedBy { it.ord }.map { it.url }
+            val result = openAi.createSketch(urls, user.style)
+            sketchRepo.save(Sketch(userId = user.id, content = result.content, tokens = result.tokens))
+            user.stage = Stage.SKETCH_READY
+            user.retryCount = 0
+            meterRegistry.counter("sketch_jobs_total", "state", "done").increment()
+        } catch (ex: Exception) {
+            log.warn("Failed to process user ${'$'}{user.id}", ex)
+            user.retryCount = (user.retryCount + 1).toShort()
+            if (user.retryCount >= 3) user.stage = Stage.SKETCH_ERROR
+            meterRegistry.counter("sketch_jobs_total", "state", "error").increment()
+        } finally {
+            user.updatedAt = LocalDateTime.now()
+            userRepo.save(user)
+            timer.stop(meterRegistry.timer("sketch_latency_seconds"))
+        }
+    }
+}

--- a/styler-service/src/main/kotlin/com/lookgen/styler/web/AdminController.kt
+++ b/styler-service/src/main/kotlin/com/lookgen/styler/web/AdminController.kt
@@ -1,0 +1,23 @@
+package com.lookgen.styler.web
+
+import com.lookgen.styler.domain.Stage
+import com.lookgen.styler.repo.UserRepository
+import org.springframework.http.ResponseEntity
+import org.springframework.transaction.annotation.Transactional
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestParam
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+class AdminController(private val userRepo: UserRepository) {
+
+    @PostMapping("/v1/admin/replay")
+    @Transactional
+    fun replay(@RequestParam uid: Long): ResponseEntity<Void> {
+        val user = userRepo.findById(uid).orElse(null) ?: return ResponseEntity.notFound().build()
+        user.stage = Stage.PENDING_SKETCH
+        user.retryCount = 0
+        userRepo.save(user)
+        return ResponseEntity.accepted().build()
+    }
+}

--- a/styler-service/src/main/kotlin/com/lookgen/styler/web/SketchController.kt
+++ b/styler-service/src/main/kotlin/com/lookgen/styler/web/SketchController.kt
@@ -1,0 +1,21 @@
+package com.lookgen.styler.web
+
+import com.lookgen.styler.repo.SketchRepository
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+@RequestMapping("/v1/sketch")
+class SketchController(private val sketchRepo: SketchRepository) {
+
+    data class SketchDto(val content: String, val tokens: Int)
+
+    @GetMapping("/{uid}")
+    fun getSketch(@PathVariable uid: Long): ResponseEntity<SketchDto> {
+        val sketch = sketchRepo.findByUserId(uid) ?: return ResponseEntity.notFound().build()
+        return ResponseEntity.ok(SketchDto(sketch.content, sketch.tokens))
+    }
+}

--- a/styler-service/src/main/resources/application.yaml
+++ b/styler-service/src/main/resources/application.yaml
@@ -1,0 +1,10 @@
+styler:
+  poll-ms: 60000
+openai:
+  api-key: dummy
+  read-timeout: 120s
+management:
+  endpoints:
+    web:
+      exposure:
+        include: health,prometheus


### PR DESCRIPTION
## Summary
- implement JPA entities and repositories for styler-service
- add scheduler that calls OpenAI and records metrics
- expose GET /v1/sketch/{uid} and POST /v1/admin/replay endpoints
- configure application properties and OpenAI client

## Testing
- `gradle -p styler-service build` *(fails: could not resolve Spring Boot plugin)*

------
https://chatgpt.com/codex/tasks/task_e_6856c6b54bec8321a87ff023c46bd665