### PR TITLE
Add webflux to styler dependencies

### DIFF
--- a/styler-service/pom.xml
+++ b/styler-service/pom.xml
@@ -22,6 +22,10 @@
     <dependencies>
         <dependency>
             <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-webflux</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-web</artifactId>
         </dependency>
         <dependency>


### PR DESCRIPTION
## Summary
- add Spring WebFlux to `styler-service` dependencies

## Testing
- `mvn package -q` *(fails: mvn not found)*

------
https://chatgpt.com/codex/tasks/task_e_68571d2bc6a48321878aae0411ff80f7