### PR TITLE
Add MySQL config to styler-service

### DIFF
--- a/styler-service/pom.xml
+++ b/styler-service/pom.xml
@@ -41,9 +41,8 @@
             <artifactId>jackson-databind</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.postgresql</groupId>
-            <artifactId>postgresql</artifactId>
-            <version>42.7.2</version>
+            <groupId>com.mysql</groupId>
+            <artifactId>mysql-connector-j</artifactId>
             <scope>runtime</scope>
         </dependency>
         <dependency>

--- a/styler-service/src/main/resources/application.yaml
+++ b/styler-service/src/main/resources/application.yaml
@@ -3,6 +3,18 @@ styler:
 openai:
   api-key: dummy
   read-timeout: 120s
+spring:
+  datasource:
+    url: jdbc:mysql://d555d.vps-kinghost.net:3306/lookgendb
+    username: ${SPRING_DATASOURCE_USERNAME}
+    password: ${SPRING_DATASOURCE_PASSWORD}
+  jpa:
+    hibernate:
+      ddl-auto: update
+    show-sql: true
+    properties:
+      hibernate:
+        dialect: org.hibernate.dialect.MySQL8Dialect
 management:
   endpoints:
     web:


### PR DESCRIPTION
## Summary
- connect `styler-service` to the same MySQL database as the backend

## Testing
- `mvn test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68574a84e98c8321b751f4d9e5c3f66c