### PR TITLE
Add scheduler for processing clientes

### DIFF
--- a/styler-service/src/main/java/com/lookgen/styler/domain/Cliente.java
+++ b/styler-service/src/main/java/com/lookgen/styler/domain/Cliente.java
@@ -1,0 +1,33 @@
+package com.lookgen.styler.domain;
+
+import jakarta.persistence.*;
+
+@Entity
+@Table(name = "cliente")
+public class Cliente {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id = 0L;
+
+    @Column(name = "precisa_processamento")
+    private boolean precisaProcessamento = true;
+
+    public Cliente() {
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public boolean isPrecisaProcessamento() {
+        return precisaProcessamento;
+    }
+
+    public void setPrecisaProcessamento(boolean precisaProcessamento) {
+        this.precisaProcessamento = precisaProcessamento;
+    }
+}

--- a/styler-service/src/main/java/com/lookgen/styler/domain/Estilo.java
+++ b/styler-service/src/main/java/com/lookgen/styler/domain/Estilo.java
@@ -1,0 +1,53 @@
+package com.lookgen.styler.domain;
+
+import jakarta.persistence.*;
+
+@Entity
+@Table(name = "estilo")
+public class Estilo {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private String nome;
+
+    private String descricao;
+
+    @Column(name = "cliente_id")
+    private Long clienteId;
+
+    public Estilo() {
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public String getNome() {
+        return nome;
+    }
+
+    public void setNome(String nome) {
+        this.nome = nome;
+    }
+
+    public String getDescricao() {
+        return descricao;
+    }
+
+    public void setDescricao(String descricao) {
+        this.descricao = descricao;
+    }
+
+    public Long getClienteId() {
+        return clienteId;
+    }
+
+    public void setClienteId(Long clienteId) {
+        this.clienteId = clienteId;
+    }
+}

--- a/styler-service/src/main/java/com/lookgen/styler/domain/FotoItem.java
+++ b/styler-service/src/main/java/com/lookgen/styler/domain/FotoItem.java
@@ -1,0 +1,56 @@
+package com.lookgen.styler.domain;
+
+import jakarta.persistence.*;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "foto_item")
+public class FotoItem {
+    @Id
+    @Column(length = 36)
+    private String id;
+
+    @Column(name = "cliente_id")
+    private Long clienteId;
+
+    private String url;
+
+    @Column(name = "data_upload")
+    private LocalDateTime dataUpload;
+
+    public FotoItem() {
+    }
+
+    public String getId() {
+        return id;
+    }
+
+    public void setId(String id) {
+        this.id = id;
+    }
+
+    public Long getClienteId() {
+        return clienteId;
+    }
+
+    public void setClienteId(Long clienteId) {
+        this.clienteId = clienteId;
+    }
+
+    public String getUrl() {
+        return url;
+    }
+
+    public void setUrl(String url) {
+        this.url = url;
+    }
+
+    public LocalDateTime getDataUpload() {
+        return dataUpload;
+    }
+
+    public void setDataUpload(LocalDateTime dataUpload) {
+        this.dataUpload = dataUpload;
+    }
+}

--- a/styler-service/src/main/java/com/lookgen/styler/repo/ClienteRepository.java
+++ b/styler-service/src/main/java/com/lookgen/styler/repo/ClienteRepository.java
@@ -1,0 +1,15 @@
+package com.lookgen.styler.repo;
+
+import com.lookgen.styler.domain.Cliente;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+public interface ClienteRepository extends JpaRepository<Cliente, Long> {
+    @Query(value = "SELECT * FROM cliente WHERE precisa_processamento = 1 LIMIT :limit FOR UPDATE SKIP LOCKED", nativeQuery = true)
+    List<Cliente> findPending(@Param("limit") int limit);
+}

--- a/styler-service/src/main/java/com/lookgen/styler/repo/EstiloRepo.java
+++ b/styler-service/src/main/java/com/lookgen/styler/repo/EstiloRepo.java
@@ -1,0 +1,10 @@
+package com.lookgen.styler.repo;
+
+import com.lookgen.styler.domain.Estilo;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface EstiloRepo extends JpaRepository<Estilo, Long> {
+    Estilo findFirstByClienteId(Long clienteId);
+}

--- a/styler-service/src/main/java/com/lookgen/styler/repo/FotoItemRepo.java
+++ b/styler-service/src/main/java/com/lookgen/styler/repo/FotoItemRepo.java
@@ -1,0 +1,12 @@
+package com.lookgen.styler.repo;
+
+import com.lookgen.styler.domain.FotoItem;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+public interface FotoItemRepo extends JpaRepository<FotoItem, String> {
+    List<FotoItem> findByClienteIdOrderByDataUpload(Long clienteId);
+}

--- a/styler-service/src/main/java/com/lookgen/styler/service/ClienteScheduler.java
+++ b/styler-service/src/main/java/com/lookgen/styler/service/ClienteScheduler.java
@@ -1,0 +1,83 @@
+package com.lookgen.styler.service;
+
+import com.lookgen.styler.domain.Cliente;
+import com.lookgen.styler.domain.FotoItem;
+import com.lookgen.styler.domain.Estilo;
+import com.lookgen.styler.repo.ClienteRepository;
+import com.lookgen.styler.repo.FotoItemRepo;
+import com.lookgen.styler.repo.EstiloRepo;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Timer;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Objects;
+
+@Service
+public class ClienteScheduler {
+
+    private static final Logger log = LoggerFactory.getLogger(ClienteScheduler.class);
+
+    private final ClienteRepository clienteRepo;
+    private final FotoItemRepo fotoItemRepo;
+    private final EstiloRepo estiloRepo;
+    private final OpenAiClient openAi;
+    private final MeterRegistry meterRegistry;
+
+    public ClienteScheduler(ClienteRepository clienteRepo, FotoItemRepo fotoItemRepo,
+                            EstiloRepo estiloRepo, OpenAiClient openAi,
+                            MeterRegistry meterRegistry) {
+        this.clienteRepo = clienteRepo;
+        this.fotoItemRepo = fotoItemRepo;
+        this.estiloRepo = estiloRepo;
+        this.openAi = openAi;
+        this.meterRegistry = meterRegistry;
+    }
+
+    @Scheduled(fixedDelayString = "${styler.poll-ms}")
+    @Transactional
+    public void tick() {
+        List<Cliente> clientes = clienteRepo.findPending(5);
+        clientes.forEach(this::processCliente);
+    }
+
+    private void processCliente(Cliente cli) {
+        Timer.Sample timer = Timer.start(meterRegistry);
+        try {
+            List<FotoItem> fotos = fotoItemRepo.findByClienteIdOrderByDataUpload(cli.getId());
+            if (fotos.isEmpty()) {
+                throw new IllegalStateException("No photos for client");
+            }
+            List<String> urls = fotos.stream()
+                    .sorted(Comparator.comparing(FotoItem::getDataUpload))
+                    .map(FotoItem::getUrl)
+                    .filter(Objects::nonNull)
+                    .toList();
+            Estilo estilo = estiloRepo.findFirstByClienteId(cli.getId());
+            String style = estilo == null ? null : estilo.getNome();
+            OpenAiClient.Response result = openAi.createSketch(urls, style);
+            if (estilo == null) {
+                estilo = new Estilo();
+                estilo.setClienteId(cli.getId());
+                estilo.setNome("Sugerido");
+            }
+            estilo.setDescricao(result.getContent());
+            estiloRepo.save(estilo);
+            cli.setPrecisaProcessamento(false);
+            meterRegistry.counter("cliente_jobs_total", "state", "done").increment();
+        } catch (Exception ex) {
+            log.warn("Failed to process client {}", cli.getId(), ex);
+            cli.setPrecisaProcessamento(false);
+            meterRegistry.counter("cliente_jobs_total", "state", "error").increment();
+        } finally {
+            clienteRepo.save(cli);
+            timer.stop(meterRegistry.timer("cliente_latency_seconds"));
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add JPA entities for `cliente`, `estilo` and `foto_item`
- add repositories for the new entities
- implement `ClienteScheduler` to call OpenAI with style and clothing photos

## Testing
- `mvn --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6859fec49610832196a778e512009e99