### PR TITLE
Update SQL dialect for MySQL 5.7

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Repositório com todos os serviços que compõem o projeto **Lookgen**.
 
 - Node.js 20+ e pnpm
 - JDK 17 ou superior
-- MySQL 8
+- MySQL 5.7+
 
 Defina as variáveis `SPRING_DATASOURCE_USERNAME` e `SPRING_DATASOURCE_PASSWORD` antes de iniciar os serviços.
 

--- a/styler-service/src/main/resources/application.yaml
+++ b/styler-service/src/main/resources/application.yaml
@@ -14,7 +14,7 @@ spring:
     show-sql: true
     properties:
       hibernate:
-        dialect: org.hibernate.dialect.MySQL8Dialect
+        dialect: org.hibernate.dialect.MySQL57Dialect
 management:
   endpoints:
     web:

--- a/ui-backend/src/main/resources/application.properties
+++ b/ui-backend/src/main/resources/application.properties
@@ -4,7 +4,7 @@ spring.datasource.password=${SPRING_DATASOURCE_PASSWORD}
 
 spring.jpa.hibernate.ddl-auto=update
 spring.jpa.show-sql=true
-spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.MySQL8Dialect
+spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.MySQL57Dialect
 
 spring.servlet.multipart.max-file-size=10MB
 spring.servlet.multipart.max-request-size=50MB


### PR DESCRIPTION
## Summary
- switch Hibernate dialects to `MySQL57Dialect`
- document MySQL 5.7 requirement in README

## Testing
- `mvn -v` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685a09de2c7c832194ea64cce5cf755f