### PR TITLE
Update OpenAI key config

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Repositório com todos os serviços que compõem o projeto **Lookgen**.
 - JDK 17 ou superior
 - MySQL 8
 
-Defina as variáveis `SPRING_DATASOURCE_USERNAME` e `SPRING_DATASOURCE_PASSWORD` antes de iniciar os serviços.
+Defina as variáveis `SPRING_DATASOURCE_USERNAME`, `SPRING_DATASOURCE_PASSWORD` e `OPENAI_API_KEY` antes de iniciar os serviços.
 
 ## Build e Execução
 

--- a/styler-service/src/main/resources/application.yaml
+++ b/styler-service/src/main/resources/application.yaml
@@ -1,7 +1,7 @@
 styler:
   poll-ms: 60000
 openai:
-  api-key: dummy
+  api-key: ${OPENAI_API_KEY}
   read-timeout: 120s
 spring:
   datasource:


### PR DESCRIPTION
## Summary
- load OpenAI API key from the `OPENAI_API_KEY` environment variable
- mention the new variable in the README

## Testing
- `gradle -p notification-service build` *(fails: Plugin org.springframework.boot not found)*
- `mvn -f styler-service/pom.xml -q package` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685ae3269e88832186c4ac1eb999dc3b