### PR TITLE
Fix OpenAI image download timeouts

### DIFF
--- a/styler-service/src/main/java/com/lookgen/styler/service/OpenAiClient.java
+++ b/styler-service/src/main/java/com/lookgen/styler/service/OpenAiClient.java
@@ -114,7 +114,12 @@ public class OpenAiClient {
         List<Object> list = new ArrayList<>();
         list.add(Map.of("type", "text", "text", "Crie um esboço:"));
         for (String u : urls) {
-            list.add(Map.of("type", "image_url", "image_url", Map.of("url", u)));
+            list.add(Map.of(
+                    "type", "image_url",
+                    "image_url", Map.of(
+                            "url", u,
+                            "detail", "low"
+                    )));
         }
         if (style != null) {
             list.add(Map.of("type", "text", "text", style));


### PR DESCRIPTION
## Summary
- lower image detail sent to OpenAI to reduce size and avoid download timeouts

## Testing
- `mvn -version` *(fails: command not found)*
- `./gradlew test` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_685c6835d3e083218f3faec6375e19d8