### PR TITLE
Fix missing version for google-cloud-storage

### DIFF
--- a/styler-service/pom.xml
+++ b/styler-service/pom.xml
@@ -53,6 +53,7 @@
         <dependency>
             <groupId>com.google.cloud</groupId>
             <artifactId>google-cloud-storage</artifactId>
+            <version>2.26.0</version>
         </dependency>
     </dependencies>
 


### PR DESCRIPTION
## Summary
- specify version for `google-cloud-storage` dependency in `styler-service`'s POM

## Testing
- `mvn -q -DskipTests package` *(fails: `mvn: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_685ee05d80988321848def4826278774